### PR TITLE
Take the session from the strategy, not the pipeline's request kwarg

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 -------
 
+1.0.2 (unreleased)
+++++++++++++++++++
+
+* Fix: take the session from the strategy instead of the pipeline's ``request``
+  keyword argument, which social-auth-core 5.x overwrites with the request data
+  when it resumes a partial pipeline (breaking the OTP round trip)
+
 1.0.1 (2025-05-19)
 ++++++++++++++++++
 

--- a/social_2fa/social_pipeline.py
+++ b/social_2fa/social_pipeline.py
@@ -6,11 +6,15 @@ from two_factor.utils import default_device
 
 @partial
 def two_factor_auth(strategy, details, *args, user=None, **kwargs):
+    # The session is read through the strategy rather than through the
+    # pipeline's ``request`` keyword argument: when social-core resumes a
+    # partial pipeline - which is exactly the pass that follows the OTP step -
+    # ``_extend_partial_pipeline`` sets that argument to the request *data*,
+    # which has no session.
     current_partial = kwargs.get("current_partial")
-    request = kwargs["request"]
-    if request.session.get("tfa_completed", False):
+    if strategy.session_get("tfa_completed", False):
         return details
     if default_device(user):
-        request.session["tfa_partial_token"] = current_partial.token
+        strategy.session_set("tfa_partial_token", current_partial.token)
         return redirect(reverse("social_2fa:two_factor_authentication"))
     return details

--- a/social_2fa/tests/test_pipeline.py
+++ b/social_2fa/tests/test_pipeline.py
@@ -41,7 +41,7 @@ class PipelineTests(TestCase):
     def test_pipeline_with_device_tfa_completed(self):
         """If two factor authentication is completed, don't redirect even if device is set"""
         self.user.staticdevice_set.create(name="default")
-        self.request.session["tfa_completed"] = True
+        self.strategy.session_set("tfa_completed", True)
         ret = social_pipeline.two_factor_auth(
             self.strategy,
             backend=self.backend,
@@ -64,3 +64,23 @@ class PipelineTests(TestCase):
             request=self.request,
         )
         self.assertIn("/two-factor-social-auth/", ret.url)
+        self.assertTrue(self.strategy.session_get("tfa_partial_token"))
+
+    def test_pipeline_with_device_on_partial_resume(self):
+        """Redirect to 2 factor authentication when the pipeline is resumed.
+
+        ``social_core.utils._extend_partial_pipeline`` sets
+        ``kwargs["request"]`` to the request *data* when a partial pipeline is
+        resumed, so the step cannot read the session off that argument.
+        """
+        self.user.staticdevice_set.create(name="default")
+        ret = social_pipeline.two_factor_auth(
+            self.strategy,
+            backend=self.backend,
+            details="details",
+            pipeline_index=11,
+            user=self.user,
+            request={"code": "code", "state": "state"},
+        )
+        self.assertIn("/two-factor-social-auth/", ret.url)
+        self.assertTrue(self.strategy.session_get("tfa_partial_token"))


### PR DESCRIPTION
> **Stacked on #6.** CI was red on `master` before this branch existed, for reasons
> unrelated to any code change, so the repair lives in its own PR and this one is based
> on it. Review/merge #6 first; GitHub will retarget this to `master` automatically.
> The diff here is only the three files below.

## The bug

`two_factor_auth` reads the session off the pipeline's `request` keyword argument:

```python
request = kwargs["request"]
if request.session.get("tfa_completed", False):
```

That works only as long as social-core leaves that argument alone, and it stopped doing
so in 5.0. `social_core.utils._extend_partial_pipeline` now does

```python
kwargs["request"] = request_data          # 4.x: kwargs.setdefault("request", request_data)
```

so on **partial pipeline resume** — which is exactly the pass that runs after the user
submits their OTP token — the step gets the request *data* (a `QueryDict`) instead of the
`HttpRequest` and raises:

```
AttributeError: 'QueryDict' object has no attribute 'session'
```

Every social login by a user with 2FA enabled 500s at `/complete/<backend>/`. Found while
upgrading a project to `social-auth-app-django` 6.0.1 / `social-auth-core` 5.1.0.

The existing tests missed it because they all pass a real `HttpRequest` as `request=`,
which is what the *first* pipeline pass gets — the substitution only happens on resume.

## The fix

Use `strategy.session_get` / `strategy.session_set`. That is social-core's own API for
session access: it is part of the `BaseStrategy` contract, so it is stable across both
pipeline passes and every strategy implementation, and under `DjangoStrategy` it reads
and writes `request.session` — the very same object the code used before. So:

* `AuthenticationView.get_partial()` keeps finding `tfa_partial_token` where it left it,
* session keys are unchanged, meaning partials already in flight when this is deployed
  still resume normally,
* nothing changes for callers on social-auth-core 4.x.

## Testing

`runtests.py social_2fa` is green against **both** `social-auth-core` 4.5.4 (with
`social-auth-app-django` 5.6.0) and 5.1.0 (with 6.0.1), so this is not a
version-conditional fix.

The new `test_pipeline_with_device_on_partial_resume` drives the step with a plain dict
as the `request` kwarg, the way a resume does — it fails on `master` with the
`AttributeError` above and passes here. `test_pipeline_with_device_tfa_completed` moves
its session write to the strategy for the same reason (with `TestStrategy` the request and
the strategy no longer share a session dict), and `test_pipeline_with_device` now also
asserts the token actually lands in the session.

flake8 / isort / black / mypy all clean. With #6 underneath, CI now covers this fix on
both generations explicitly (`social-auth-app-django` 5.6.* and 6.0.*).

## Note

The project that hit this is carrying a local copy of the fixed step as a stopgap
([BlenderKit/BlenderKit-server#3595](https://github.com/BlenderKit/Blendkit-server/pull/3595));
it gets deleted as soon as this is released.
