### PR TITLE
Repair CI and cover both social-auth-app-django generations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,9 @@ jobs:
       matrix:
         DJANGO_VERSION: ['4.1.*', '4.2.*', '5.0.*', '5.1.*', '5.2.*']
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        # 'resolver' means "whatever pip picks for this Django version";
+        # the pinned combinations are added under `include` below.
+        SAAD_VERSION: ['resolver']
         exclude:
           # Django 4.1
           - DJANGO_VERSION: '4.1.*'
@@ -44,6 +47,24 @@ jobs:
           # Django 5.2
           - DJANGO_VERSION: '5.2.*'
             python-version: '3.9'
+        include:
+          # social-auth-app-django 6.0 made social:begin POST-only and moved to
+          # social-auth-core 5.x, which overwrites the pipeline's `request`
+          # kwarg on partial resume. Both sides of that break need coverage, so
+          # pin them explicitly instead of trusting the resolver. 5.x needs
+          # Django >= 5.1, 6.x needs Django >= 5.2.
+          - DJANGO_VERSION: '5.1.*'
+            python-version: '3.13'
+            SAAD_VERSION: '5.6.*'
+          - DJANGO_VERSION: '5.2.*'
+            python-version: '3.13'
+            SAAD_VERSION: '5.6.*'
+          - DJANGO_VERSION: '5.2.*'
+            python-version: '3.10'
+            SAAD_VERSION: '6.0.*'
+          - DJANGO_VERSION: '5.2.*'
+            python-version: '3.13'
+            SAAD_VERSION: '6.0.*'
       fail-fast: false
 
     services:
@@ -60,10 +81,10 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
               python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v4
@@ -71,45 +92,62 @@ jobs:
           path: ~/.cache/pip
           key: ${{ hashFiles('setup.py') }}-${{ matrix.DJANGO_VERSION }}
 
+      # One resolution pass, with the pinned versions in it. Installing the
+      # requirements first and pinning Django afterwards leaves the set
+      # inconsistent - pip does not revisit what it already installed, so on
+      # Python 3.10+ an old Django ends up next to a social-auth-app-django /
+      # model-bakery / django-formtools that require Django >= 5.2, and
+      # `social_django.models` fails to import.
       - name: Install
         run: |
-           pip install setuptools
-           python setup.py develop
-           pip install -e .
-           pip install -r requirements_test.txt
-           pip install coveralls
-           pip install psycopg2
-           pip install Django==${{ matrix.DJANGO_VERSION }}
-           pip install codecov
+           pip install --upgrade pip
+           if [ "${{ matrix.SAAD_VERSION }}" != "resolver" ]; then
+             SAAD_PIN="social-auth-app-django==${{ matrix.SAAD_VERSION }}"
+           else
+             SAAD_PIN=""
+           fi
+           pip install -e . -r requirements_test.txt coveralls psycopg2 \
+             "Django==${{ matrix.DJANGO_VERSION }}" $SAAD_PIN
+           pip list | grep -E '^(Django|social-auth-app-django|social-auth-core) '
 
       - name: Testing
         run: |
           PYTHONPATH=`pwd` python -W error::DeprecationWarning -m coverage run --source social_2fa runtests.py social_2fa
-          coverage xml && codecov
+          coverage xml
         env:
           DATABASE_URL: "postgresql://postgres:postgres@localhost/postgres"
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+        continue-on-error: true
 
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ hashFiles('setup.py') }}-${{ matrix.DJANGO_VERSION }}
+          key: lint-${{ hashFiles('setup.py') }}
 
       - name: Install
         run: |
-          pip install flake8 isort black mypy django-stubs dj_database_url types-six types-requests types-mock setuptools
-          python setup.py develop
+          pip install --upgrade pip
+          pip install flake8 isort black mypy django-stubs dj_database_url types-six types-requests types-mock
           pip install -e .
           pip install -r requirements.txt
       - name: Running Flake8
         run: flake8
+      # `python -m isort` fails from isort 9 on: the package ships a compiled
+      # `__main__` extension module, which runpy cannot execute.
       - name: Running isort
-        run: python -m isort social_2fa tests --check-only --diff
+        run: isort social_2fa tests --check-only --diff
       - name: Running black
         run: black --check social_2fa tests
       - name: Running mypy

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 envlist =
     {py310,py311,py312,py313}-django-52
+    py313-django-52-{saad5,saad6}
+    py313-django-51-saad5
     {py310,py311,py312,py313}-django-51
     {py310,py311,py312}-django-50
     {py39,py310,py311,py312}-django-42
@@ -11,6 +13,11 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/social_2fa
 commands = coverage run --source social_2fa runtests.py social_2fa
 deps =
+    # social-auth-app-django 6.0 moved to social-auth-core 5.x, which treats the
+    # pipeline's `request` kwarg differently on partial resume - keep both sides
+    # of that break covered.
+    saad5: social-auth-app-django>=5.6,<6.0
+    saad6: social-auth-app-django>=6.0,<7.0
     django-52: Django>=5.2,<5.3
     django-51: Django>=5.1,<5.2
     django-50: Django>=5.0,<5.1


### PR DESCRIPTION
CI is red on `master`, and has been for a while — I hit it while preparing #5, so here it
is on its own branch, off `master`, with no behaviour change.

Evidence it is not any one PR's fault: a manual `workflow_dispatch` on untouched `master`
([run 33115334888](https://github.com/PetrDlouhy/dj-two-factor-social-auth/actions/runs/33115334888))
fails every job the same way. There was no green run left to compare against — the last
push was May 2025 and GitHub had aged the older runs out of retention.

## Three independent breakages

**1. lint — `python -m isort`.** From isort 9 the package ships `__main__` as a *compiled*
extension module (`__main__.cpython-3xx-….so`) shadowing the `.py`, and runpy cannot
execute that: `No code object available for isort.__main__`. The console script is fine.

**2. install — `python setup.py develop`.** Resolves through the retired setuptools path
and dies before a single test runs:

```
error: typing-extensions 4.12.2 is installed but typing-extensions>=4.13.2 is required by {'cryptography'}
```

The very next line, `pip install -e .`, already does the job.

**3. install order — pins applied after the requirements.** This one was hidden behind #2.
The job installed `requirements_test.txt` first and pinned Django afterwards; pip does not
revisit what it already installed, so on Python 3.10+ every pre-5.1 Django row ended up
with a `social-auth-app-django` / `model-bakery` / `django-formtools` that require Django
≥ 5.2, and the suite died importing `social_django.models`:

```
social-auth-app-django 6.0.1 requires Django>=5.2, but you have django 4.2.30 which is incompatible.
...
File ".../social_django/models.py", line 28, in <module>
```

The Python 3.9 rows passed only because that interpreter forced old versions of
everything. Fixed by resolving once with the pins included — Django 4.2 then correctly
gets `social-auth-app-django` 5.4.3.

## The social-auth-app-django axis

Until now that version was whatever pip happened to pick for a given Django, so the
5.x → 6.x boundary was never deliberately covered — and that boundary matters: 6.x moves
to `social-auth-core` 5.x, which overwrites the pipeline's `request` kwarg on partial
resume (the bug #5 fixes). Both sides are now pinned explicitly, on the Django versions
each actually supports (5.x needs Django ≥ 5.1, 6.x needs ≥ 5.2 — a naive cross-product
would just have downgraded SAAD again and lied about the coverage). `tox` grows matching
`saad5` / `saad6` factors so a local run reproduces it.

## Also

`checkout` / `setup-python` bumped off the v2 actions (they were being force-migrated to
Node 24 with a deprecation warning), lint interpreter pinned, stray
`matrix.DJANGO_VERSION` dropped from the lint cache key (that job has no matrix), and the
retired `codecov` PyPI uploader replaced with `codecov-action` (non-blocking).

## Verification

Every shape the matrix now has was run locally first: the pins resolve as intended
(5.6.0 → social-auth-core 4.9.1; 6.0.1 → 5.1.0; Django 4.2 → 5.4.3) and the suite passes
under `-W error::DeprecationWarning`. CI on this branch is the real check.

## Note, not changed here

The `postgres` service and `pip install psycopg2` look like dead weight —
`tests/settings.py` hardcodes sqlite3 and never reads the `DATABASE_URL` the job sets.
Dropping them would save a container and a source build per job, but that is a separate
decision from getting CI green.

---

#5 is rebased onto this branch and should merge after it.
