### PR TITLE
Take the session from the strategy, not the pipeline's request kwarg (re-apply, #5 missed master)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 -------
 
+1.0.2 (unreleased)
+++++++++++++++++++
+
+* Fix: take the session from the strategy instead of the pipeline's ``request``
+  keyword argument, which social-auth-core 5.x overwrites with the request data
+  when it resumes a partial pipeline (breaking the OTP round trip)
+
 1.0.1 (2025-05-19)
 ++++++++++++++++++
 

--- a/social_2fa/social_pipeline.py
+++ b/social_2fa/social_pipeline.py
@@ -6,11 +6,15 @@ from two_factor.utils import default_device
 
 @partial
 def two_factor_auth(strategy, details, *args, user=None, **kwargs):
+    # The session is read through the strategy rather than through the
+    # pipeline's ``request`` keyword argument: when social-core resumes a
+    # partial pipeline - which is exactly the pass that follows the OTP step -
+    # ``_extend_partial_pipeline`` sets that argument to the request *data*,
+    # which has no session.
     current_partial = kwargs.get("current_partial")
-    request = kwargs["request"]
-    if request.session.get("tfa_completed", False):
+    if strategy.session_get("tfa_completed", False):
         return details
     if default_device(user):
-        request.session["tfa_partial_token"] = current_partial.token
+        strategy.session_set("tfa_partial_token", current_partial.token)
         return redirect(reverse("social_2fa:two_factor_authentication"))
     return details

--- a/social_2fa/tests/test_pipeline.py
+++ b/social_2fa/tests/test_pipeline.py
@@ -41,7 +41,7 @@ class PipelineTests(TestCase):
     def test_pipeline_with_device_tfa_completed(self):
         """If two factor authentication is completed, don't redirect even if device is set"""
         self.user.staticdevice_set.create(name="default")
-        self.request.session["tfa_completed"] = True
+        self.strategy.session_set("tfa_completed", True)
         ret = social_pipeline.two_factor_auth(
             self.strategy,
             backend=self.backend,
@@ -64,3 +64,23 @@ class PipelineTests(TestCase):
             request=self.request,
         )
         self.assertIn("/two-factor-social-auth/", ret.url)
+        self.assertTrue(self.strategy.session_get("tfa_partial_token"))
+
+    def test_pipeline_with_device_on_partial_resume(self):
+        """Redirect to 2 factor authentication when the pipeline is resumed.
+
+        ``social_core.utils._extend_partial_pipeline`` sets
+        ``kwargs["request"]`` to the request *data* when a partial pipeline is
+        resumed, so the step cannot read the session off that argument.
+        """
+        self.user.staticdevice_set.create(name="default")
+        ret = social_pipeline.two_factor_auth(
+            self.strategy,
+            backend=self.backend,
+            details="details",
+            pipeline_index=11,
+            user=self.user,
+            request={"code": "code", "state": "state"},
+        )
+        self.assertIn("/two-factor-social-auth/", ret.url)
+        self.assertTrue(self.strategy.session_get("tfa_partial_token"))


### PR DESCRIPTION
#5 was merged into `fix/ci-and-test-matrix` rather than into `master`.

I had retargeted #5 onto #6's branch so its diff would show only the fix and its CI would
run on the repaired workflow, expecting GitHub to retarget it to `master` once #6 merged.
#6 merged at 21:06:00 and #5 at 21:06:39 — 39 seconds later, before that retarget took
effect — so the fix landed on the already-merged CI branch and never reached `master`.

`master` today still has the bug:

```console
$ git show origin/master:social_2fa/social_pipeline.py | grep -n 'kwargs\["request"\]'
10:    request = kwargs["request"]
```

This re-applies the same commit on top of `master`. Identical content to what #5 reviewed
— `git diff origin/master origin/fix/ci-and-test-matrix` is exactly these three files.

Sorry for the extra round trip; stacking the PRs was my suggestion and this is its failure
mode. Nothing else was lost — #6's CI repair did land on `master`.
